### PR TITLE
fix: try to flush first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(postgrespp CXX)
 


### PR DESCRIPTION
hoping that handler will not be called before write operations are
finished.

Previously, the write-ready callback could be called after the handler
is executed (when PQflush is not actually needed and could return 0 on the
first call without doing anything, and the response could already be
read). We want the handler to called when all operations are completed.

I still assume that PQgetResult cannot return nullptr, indicating completion,
before PQflush returns 0.

Fixes: #2